### PR TITLE
update info texts on welcome and about page

### DIFF
--- a/app/views/welcome/about.html.erb
+++ b/app/views/welcome/about.html.erb
@@ -5,31 +5,33 @@
 
     <p>SoundDrop was first created in 2014 by Brigitte, Caroline and Michelle, then interns at SoundCloud, with Duana Stanley as product manager. Initially, SoundDrop was based on QR codes. 'Drops' were located throughout the SoundCloud office in Berlin, where employees created personal stories attached to interesting objects and places.</p>
 
-    <p>Over the summer 2015, the project was followed up by Rails Girls Summer of Code fellows Franzi and Nynne with coaching from Erik Michaels-Ober and mentoring from Duana Stanley and Tam Eastley. SoundDrop is maintained by a small core group of diehard SoundDroppers :)</p>
+    <p>Over the summer 2015, the project was followed up by <i>Rails Girls Summer of Code</i> fellows Franzi and Nynne with coaching from Erik Michaels-Ober and mentoring from Duana Stanley and Tam Eastley. </p>
 
-    <p>Main Contributors:</p>
+    <p>During the <i>Rails Girls Summer of Code</i> in 2016, Dayana Mick and Johanna Lang (aka Team "joda") contributed to the app, e.g. by building a JSON API and embedding a Google Map into the Welcome Page. The QR function is now obsolete and Drops can be found via a radius request. 
+    All this would not have been possible without the support by the mentors Tam and Duana and all the helpful coaches at Absolventa GmbH. </p>
 
-    <div>Duana Stanley, Erik Michaels-Ober, Tam Eastley</div>
 
-    <div>Brigitte, Caroline, Franzi, Michelle, Nynne, Dayana, Johanna.</div>
+    <h4>SoundDrop is maintained by a small core group of diehard SoundDroppers :)</h4>
+
+    <div>
+      <ul>
+        <li>Duana Stanley</li>
+        <li>Tam Eastley</li>
+        <li>Erik Michaels-Ober</li>
+        <li>Brigitte</li>
+        <li>Caroline</li>
+        <li>Franzi</li>
+        <li>Michelle</li>
+        <li>Nynne</li>
+        <li>Dayana</li>
+        <li>Johanna</li>
+      </ul>
+    </div>
 
     <p>
       <div>A huge thanks goes out to everyone who has helped to make this project possible:</div>
-      <ul>
-        <li>Brian Egan</li>
-        <li>Chris Berghout</li>
-        <li>Dennis Cahillane</li>
-        <li>Ellen König</li>
-        <li>Hannes Tyden</li>
-        <li>Jan Kischkel</li>
-        <li>Jano González</li>
-        <li>JP Bochi</li>
-        <li>Matthias Georgi</li>
-        <li>Sergio Gil</li>
-        <li>Tobi Biehlolawek</li>
-        <li>Tom Stuart</li>
-        <li>Willam Boxhall</li>
-      </ul>
+      <div>Brian Egan, Chris Berghout, Dennis Cahillane, Ellen König, Hannes Tyden, Jan Kischkel,  Jano González, JP Bochi, Matthias Georgi, Sergio Gil, Tobi Biehlolawek, Tom Stuart and Willam Boxhall. 
+      </div>
     </p>
   </div>
 </body>

--- a/app/views/welcome/about.html.erb
+++ b/app/views/welcome/about.html.erb
@@ -25,6 +25,7 @@
         <li>Nynne</li>
         <li>Dayana</li>
         <li>Johanna</li>
+        <li>Carsten</li>
       </ul>
     </div>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <h1>Welcome to SoundDrop!</h1>
 
-    <p>SoundDrop lets you record stories or create playlists of your favourite songs and connect them to any place you wish via geolocation.</p>
+    <p>SoundDrop lets you record stories, soundscapes or create playlists of your favourite songs and connect them to any place you wish via geolocation.</p>
 
     <p>With SoundDrop you can leave an audible mark anywhere and share it with friends. Wish to leave a playlist along your favourite bike route through town? Or create a guided tour for a museum exhibition? Want to tell a personal story about a famous landmark, or guide your friends to your favourite spots in a foreign city? SoundDrop let's you share the sound.</p>
 


### PR DESCRIPTION
These are some minor changes:
- updating the infos within the about text (added a paragraph about the jodas)
- put collaborators in a different order (make the more productive ones more visible)

Please feel free to update more. Who else is an active collaborator and who isn't anymore and can therefore be moved to the "Thanks to..." list? (Or should we create two lists? One with active collaborators and and one with the former?) And some people have last names and some don't, maybe we can make them more similar?
