### PR TITLE
Remove RSpec warning for expectation on nil

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe ApplicationHelper do
       let(:current_user) { JSON.parse(File.read('spec/fixtures/eric.json')) }
 
       before do
-        allow(helper.client).to receive(:present?).and_return true
         allow(helper).to receive(:client).and_return client
         allow(client).to receive(:get).with('/me').and_return current_user
       end


### PR DESCRIPTION
Removes the following warning when running the specs:

> WARNING: An expectation of `:present?` was set on `nil`. To allow expectations on `nil` and suppress this message, set `config.allow_message_expectations_on_nil` to `true`. To disallow expectations on `nil`, set `config.allow_message_expectations_on_nil` to `false`. Called from /Users/czimmer/Development/RGSoC/sounddrop/spec/helpers/application_helper_spec.rb:40:in `block (4 levels) in <top (required)>'.
